### PR TITLE
fix: fix soundness issue related to storing a reference in `Ref` and `RefMut`.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,7 @@
-use super::{cell::AtomicCell, refs::RefMut};
+use super::{
+    cell::AtomicCell,
+    refs::{Ref, RefMut},
+};
 
 #[test]
 fn test_borrow() {
@@ -32,4 +35,36 @@ fn test_unsized() {
     assert_eq!(cell.borrow()[0], 42);
     cell.borrow_mut()[0] = 11;
     assert_eq!(cell.borrow()[0], 11);
+}
+
+// For Miri to catch issues when calling a function.
+//
+// See how this scenerio affects std::cell::RefCell implementation:
+// https://github.com/rust-lang/rust/issues/63787
+//
+// Also see relevant unsafe code guidelines issue:
+// https://github.com/rust-lang/unsafe-code-guidelines/issues/125
+#[test]
+fn drop_and_borrow_in_fn_call() {
+    {
+        fn drop_and_borrow(cell: &AtomicCell<i32>, borrow: Ref<'_, i32>) {
+            drop(borrow);
+            *cell.borrow_mut() = 0;
+        }
+
+        let a = AtomicCell::new(0);
+        let borrow = a.borrow();
+        drop_and_borrow(&a, borrow);
+    }
+
+    {
+        fn drop_and_borrow_mut(cell: &AtomicCell<i32>, borrow: RefMut<'_, i32>) {
+            drop(borrow);
+            *cell.borrow_mut() = 0;
+        }
+
+        let a = AtomicCell::new(0);
+        let borrow = a.borrow_mut();
+        drop_and_borrow_mut(&a, borrow);
+    }
 }


### PR DESCRIPTION
Fixes: #2

Adds a test that fails miri before this PR, and passes after it.