### PR TITLE
make as many methods as possible available in `const` contexts 

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -62,7 +62,7 @@ impl<T> AtomicCell<T> {
     /// let five = c.into_inner();
     /// ```
     #[inline(always)]
-    pub fn into_inner(self) -> T {
+    pub const fn into_inner(self) -> T {
         // TODO: Add `const` when `UnsafeCell::into_inner` is stabilized as const.
         self.value.into_inner()
     }
@@ -365,7 +365,7 @@ where
     /// assert_eq!(c, AtomicCell::new(6));
     /// ```
     #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
+    pub const fn get_mut(&mut self) -> &mut T {
         self.value.get_mut()
     }
 

--- a/src/refs/immutable.rs
+++ b/src/refs/immutable.rs
@@ -211,7 +211,7 @@ where
     /// }
     /// ```
     #[inline]
-    pub fn into_split(r: Ref<'a, T>) -> (NonNull<T>, AtomicBorrow<'a>) {
+    pub const fn into_split(r: Ref<'a, T>) -> (NonNull<T>, AtomicBorrow<'a>) {
         (r.value, r.borrow)
     }
 

--- a/src/refs/mutable.rs
+++ b/src/refs/mutable.rs
@@ -399,7 +399,7 @@ where
     /// assert!(cell.try_borrow().is_none());
     /// assert!(cell.try_borrow_mut().is_none());
     /// ```
-    pub fn leak(mut r: RefMut<'a, T>) -> &'a mut T {
+    pub const fn leak(mut r: RefMut<'a, T>) -> &'a mut T {
         core::mem::forget(r.borrow);
         // SAFETY: We hold an exclusive lock on the pointer.
         unsafe { r.value.as_mut() }

--- a/src/refs/mutable.rs
+++ b/src/refs/mutable.rs
@@ -236,7 +236,7 @@ where
     /// }
     /// ```
     #[inline]
-    pub fn into_split(r: RefMut<'a, T>) -> (NonNull<T>, AtomicBorrowMut<'a>) {
+    pub const fn into_split(r: RefMut<'a, T>) -> (NonNull<T>, AtomicBorrowMut<'a>) {
         (r.value, r.borrow)
     }
 


### PR DESCRIPTION
functions modified:

`AtomicCell::into_inner()` (const stable as of 1.83)
`AtomicCell::as_mut()` (const stable as of 1.83)
`Ref::into_split()` 
`RefMut::into_split()`
`RefMut::leak()` (available to be const since 1.83)

most of these functions would probably not affect the entire structure of programs, but it could perhaps break people's projects if they are pre-1.83 rust. All of these functions probably don't need to be `const` either, (except `AtomicCell::into_inner()`), but it could possibly provide more flexibility for developers using this API.

